### PR TITLE
Log transfers in pseudo-NetLogger format

### DIFF
--- a/src/lia/util/net/common/NetloggerRecord.java
+++ b/src/lia/util/net/common/NetloggerRecord.java
@@ -1,0 +1,143 @@
+package lia.util.net.common;
+
+import java.net.InetAddress;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * @author nlmills@g.clemson.edu
+ */
+public class NetloggerRecord {
+    /** the size of the data block read from the disk and posted to the network */
+    private int block;
+    /** tcp buffer size (if 0 system defaults were used) */
+    private int buffer;
+    /** the FTP rfc959 completion code of the transfer */
+    private String code = "429";  // = "Connection closed; transfer aborted."
+    /** time the transfer completed */
+    private Date completed = new Date();
+    /** the destination host */
+    private InetAddress destination = InetAddress.getLoopbackAddress();
+    /** hostname of the server */
+    private InetAddress host = InetAddress.getLoopbackAddress();
+    /** the total number of bytes transferred */
+    private long nbytes;
+    /** time the transfer started */
+    private Date start = completed;
+    /** the number of parallel TCP streams used in the transfer */
+    private int streams;
+    /** the transfer type (RETR or STOR) */
+    private String type = "RETR";
+
+    public int getBuffer() {
+        return buffer;
+    }
+
+    public void setBuffer(int buffer) {
+        this.buffer = buffer;
+    }
+
+    public int getBlock() {
+        return block;
+    }
+
+    public void setBlock(int block) {
+        this.block = block;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Date getCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(Date completed) {
+        this.completed = completed;
+    }
+
+    public InetAddress getDestination() {
+        return destination;
+    }
+
+    public void setDestination(InetAddress destination) {
+        this.destination = destination;
+    }
+
+    public InetAddress getHost() {
+        return host;
+    }
+
+    public void setHost(InetAddress host) {
+        this.host = host;
+    }
+
+    public long getNbytes() {
+        return nbytes;
+    }
+
+    public void setNbytes(long nbytes) {
+        this.nbytes = nbytes;
+    }
+
+    public Date getStart() {
+        return start;
+    }
+
+    public void setStart(Date start) {
+        this.start = start;
+    }
+
+    public int getStreams() {
+        return streams;
+    }
+
+    public void setStreams(int streams) {
+        this.streams = streams;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public static String toULMDate(Date date) {
+        // year month day hour minute second . millisecond
+        SimpleDateFormat ulmFormat = new SimpleDateFormat("yyyyMMddHHmmss.SSS");
+        // Date only has millisecond precision, so tack on zeros for microseconds
+        String ulmDate = ulmFormat.format(date) + "000";
+
+        return ulmDate;
+    }
+
+    public String toULMString() {
+        String ulm = String.join(" ",
+                "DATE="+toULMDate(completed),
+                "HOST="+host.getHostName(),
+                "PROG=fdt",
+                //XXX what about NL.EVNT=FTP_INFO?
+                "START="+toULMDate(start),
+                "BUFFER="+buffer,
+                "BLOCK="+block,
+                "NBYTES="+nbytes,
+                "STREAMS="+streams,
+                "DEST=["+destination.getHostAddress()+"]",
+                "TYPE="+type,
+                "CODE="+code);
+
+        return ulm;
+    }
+
+    @Override
+    public String toString() {
+        return toULMString();
+    }
+}

--- a/src/lia/util/net/common/NetloggerRecord.java
+++ b/src/lia/util/net/common/NetloggerRecord.java
@@ -17,9 +17,9 @@ public class NetloggerRecord {
     /** time the transfer completed */
     private Date completed = new Date();
     /** the destination host */
-    private InetAddress destination = InetAddress.getLoopbackAddress();
+    private InetAddress destination = Utils.getLoopbackAddress();
     /** hostname of the server */
-    private InetAddress host = InetAddress.getLoopbackAddress();
+    private InetAddress host = Utils.getLoopbackAddress();
     /** the total number of bytes transferred */
     private long nbytes;
     /** time the transfer started */
@@ -119,7 +119,7 @@ public class NetloggerRecord {
     }
 
     public String toULMString() {
-        String ulm = String.join(" ",
+        String ulm = Utils.joinString(" ",
                 "DATE="+toULMDate(completed),
                 "HOST="+host.getHostName(),
                 "PROG=fdt",

--- a/src/lia/util/net/common/Utils.java
+++ b/src/lia/util/net/common/Utils.java
@@ -11,11 +11,13 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.StringWriter;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SelectionKey;
@@ -1709,5 +1711,31 @@ public final class Utils {
 
         sb.append("}");
         return sb.toString();
+    }
+
+    public static String joinString(CharSequence delimiter, CharSequence... elements) {
+        StringBuilder sb = new StringBuilder();
+
+        if (elements.length > 0) {
+            sb.append(elements[0]);
+        }
+        for (int i = 1; i < elements.length; i++) {
+            sb.append(delimiter).append(elements[i]);
+        }
+
+        return sb.toString();
+    }
+
+    public static InetAddress getLoopbackAddress() {
+        InetAddress localhost = null;
+
+        try {
+            byte[] address = {127, 0, 0, 1};  // 127.0.0.1
+            localhost = InetAddress.getByAddress("localhost", address);
+        } catch (UnknownHostException ex) {
+            // do nothing
+        }
+
+        return localhost;
     }
 }


### PR DESCRIPTION
Outputs a log entry after each transfer to System.out. The output
format resembles the NetLogger format described at
http://netlogger.lbl.gov. Log output is machine-friendly and suitable
for automated monitoring dashboards,
e.g. http://prp-maddash.calit2.optiputer.net/maddash-webui/index.cgi.